### PR TITLE
Support attributes with dots in attribute name

### DIFF
--- a/index.js
+++ b/index.js
@@ -199,7 +199,7 @@ function parse(xml, options = {}) {
     }
 
     function attribute() {
-        const m = match(/([\w:-]+)\s*=\s*("[^"]*"|'[^']*'|\w+)\s*/);
+        const m = match(/([\w-:.]+)\s*=\s*("[^"]*"|'[^']*'|\w+)\s*/);
         if (!m) return;
         return {name: m[1], value: strip(m[2])}
     }

--- a/test/index.js
+++ b/test/index.js
@@ -96,13 +96,14 @@ describe('XML Parser', function() {
     });
 
     it('should support tags with attributes', function() {
-        const node = parse('<foo bar=baz some="stuff here" whatever=\'whoop\'></foo>');
+        const node = parse('<foo bar=baz some="stuff here" a.1="2" whatever=\'whoop\'></foo>');
         assert.deepEqual(node.root, {
             type: 'Element',
             name: 'foo',
             attributes: {
                 bar: 'baz',
                 some: 'stuff here',
+                'a.1': '2',
                 whatever: 'whoop'
             },
             children: []


### PR DESCRIPTION
Use the same pattern (`[\w-:.]+`) for attribute names as for tag names and processing instruction names.