### PR TITLE
Fix parsing of xml-stylesheet as first processing instruction

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -129,7 +129,7 @@ function parseDocument(): XmlParserResult {
 }
 
 function processingInstruction(matchDeclaration: boolean): XmlParserNodeWrapper<XmlParserProcessingInstructionNode>|undefined {
-    const m = matchDeclaration ? match(/^<\?(xml)\s*/) : match(/^<\?([\w-:.]+)\s*/);
+    const m = matchDeclaration ? match(/^<\?(xml(-stylesheet)?)\s*/) : match(/^<\?([\w-:.]+)\s*/);
     if (!m) return;
 
     // tag

--- a/test/index.ts
+++ b/test/index.ts
@@ -580,6 +580,30 @@ describe('XML Parser', function() {
         });
     });
 
+    it('should correctly parse xml-stylesheet as first processing instruction', function() {
+        const node = xmlParser('<?xml-stylesheet href="style.xsl" type="text/xsl" ?><foo></foo>');
+
+        const root: XmlParserElementNode = {
+            type: 'Element',
+            name: 'foo',
+            attributes: {},
+            children: []
+        };
+
+        assert.deepEqual(node, {
+            declaration: {
+                name: 'xml-stylesheet',
+                type: 'ProcessingInstruction',
+                attributes: {
+                    href: 'style.xsl',
+                    type: 'text/xsl'
+                }
+            },
+            root: root,
+            children: [root]
+        });
+    });
+
     it('should support complex XML', function() {
         const node = xmlParser(`<?xml version="1.0" encoding="utf-8"?>
 <!-- Load the stylesheet -->


### PR DESCRIPTION
If `xml-stylesheet` is the first processing instruction in the document to parse, it was incorrectly parsed as a `xml` processing instruction.

Having a `xml-stylesheet` processing instruction at the top of the document to parse is not invalid accorsing to [XSLT specification](https://www.w3.org/TR/xslt20/#d5e4799).